### PR TITLE
feat: add `DesiredReplicas` inside `State` struct

### DIFF
--- a/app/http/routes/strategies.go
+++ b/app/http/routes/strategies.go
@@ -157,7 +157,7 @@ func instanceStateToRenderOptionsRequestState(instanceState *instance.State) pag
 		Name:            instanceState.Name,
 		Status:          instanceState.Status,
 		CurrentReplicas: instanceState.CurrentReplicas,
-		DesiredReplicas: 1, //instanceState.DesiredReplicas,
+		DesiredReplicas: instanceState.DesiredReplicas,
 		Error:           err,
 	}
 }

--- a/app/http/routes/strategies_test.go
+++ b/app/http/routes/strategies_test.go
@@ -134,11 +134,11 @@ func TestServeStrategy_ServeBlocking(t *testing.T) {
 				},
 				session: sessions.SessionState{
 					Instances: createMap([]*instance.State{
-						{Name: "nginx", Status: instance.NotReady, CurrentReplicas: 0},
+						{Name: "nginx", Status: instance.NotReady, CurrentReplicas: 0, DesiredReplicas: 1},
 					}),
 				},
 			},
-			expectedBody:        `{"session":{"instances":[{"instance":{"name":"nginx","currentReplicas":0,"status":"not-ready"},"error":null}],"status":"not-ready"}}`,
+			expectedBody:        `{"session":{"instances":[{"instance":{"name":"nginx","currentReplicas":0,"desiredReplicas":1,"status":"not-ready"},"error":null}],"status":"not-ready"}}`,
 			expectedHeaderKey:   "X-Sablier-Session-Status",
 			expectedHeaderValue: "not-ready",
 		},
@@ -151,11 +151,11 @@ func TestServeStrategy_ServeBlocking(t *testing.T) {
 				},
 				session: sessions.SessionState{
 					Instances: createMap([]*instance.State{
-						{Name: "nginx", Status: instance.Ready, CurrentReplicas: 1},
+						{Name: "nginx", Status: instance.Ready, CurrentReplicas: 1, DesiredReplicas: 1},
 					}),
 				},
 			},
-			expectedBody:        `{"session":{"instances":[{"instance":{"name":"nginx","currentReplicas":1,"status":"ready"},"error":null}],"status":"ready"}}`,
+			expectedBody:        `{"session":{"instances":[{"instance":{"name":"nginx","currentReplicas":1,"desiredReplicas":1,"status":"ready"},"error":null}],"status":"ready"}}`,
 			expectedHeaderKey:   "X-Sablier-Session-Status",
 			expectedHeaderValue: "ready",
 		},

--- a/app/instance/instance.go
+++ b/app/instance/instance.go
@@ -9,6 +9,7 @@ var Unrecoverable = "unrecoverable"
 type State struct {
 	Name            string `json:"name"`
 	CurrentReplicas int    `json:"currentReplicas"`
+	DesiredReplicas int    `json:"desiredReplicas"`
 	Status          string `json:"status"`
 	Message         string `json:"message,omitempty"`
 }
@@ -17,54 +18,42 @@ func (instance State) IsReady() bool {
 	return instance.Status == Ready
 }
 
-func ErrorInstanceState(name string, err error) (State, error) {
+func ErrorInstanceState(name string, err error, desiredReplicas int) (State, error) {
 	log.Error(err.Error())
 	return State{
 		Name:            name,
 		CurrentReplicas: 0,
+		DesiredReplicas: desiredReplicas,
 		Status:          Unrecoverable,
 		Message:         err.Error(),
 	}, err
 }
 
-func UnrecoverableInstanceState(name string, message string) (State, error) {
+func UnrecoverableInstanceState(name string, message string, desiredReplicas int) (State, error) {
 	log.Warn(message)
 	return State{
 		Name:            name,
 		CurrentReplicas: 0,
+		DesiredReplicas: desiredReplicas,
 		Status:          Unrecoverable,
 		Message:         message,
 	}, nil
 }
 
-func ReadyInstanceState(name string) (State, error) {
+func ReadyInstanceState(name string, replicas int) (State, error) {
 	return State{
 		Name:            name,
-		CurrentReplicas: 1,
+		CurrentReplicas: replicas,
+		DesiredReplicas: replicas,
 		Status:          Ready,
 	}, nil
 }
 
-func ReadyInstanceStateOfReplicas(name string, replicas int) (State, error) {
+func NotReadyInstanceState(name string, currentReplicas int, desiredReplicas int) (State, error) {
 	return State{
 		Name:            name,
-		CurrentReplicas: replicas,
-		Status:          Ready,
-	}, nil
-}
-
-func NotReadyInstanceState(name string) (State, error) {
-	return State{
-		Name:            name,
-		CurrentReplicas: 0,
-		Status:          NotReady,
-	}, nil
-}
-
-func NotReadyInstanceStateOfReplicas(name string, replicas int) (State, error) {
-	return State{
-		Name:            name,
-		CurrentReplicas: replicas,
+		CurrentReplicas: currentReplicas,
+		DesiredReplicas: desiredReplicas,
 		Status:          NotReady,
 	}, nil
 }

--- a/app/providers/docker_classic_test.go
+++ b/app/providers/docker_classic_test.go
@@ -38,6 +38,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -54,6 +55,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 1,
+				DesiredReplicas: 1,
 				Status:          instance.Ready,
 			},
 			wantErr:       false,
@@ -70,6 +72,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -86,6 +89,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container is unhealthy: curl http://localhost failed (1)",
 			},
@@ -103,6 +107,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 1,
+				DesiredReplicas: 1,
 				Status:          instance.Ready,
 			},
 			wantErr:       false,
@@ -119,6 +124,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -135,6 +141,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -151,6 +158,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -167,6 +175,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr:       false,
@@ -183,6 +192,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container exited with code \"137\"",
 			},
@@ -200,6 +210,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container in \"dead\" state cannot be restarted",
 			},
@@ -217,6 +228,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container with name \"nginx\" was not found",
 			},
@@ -228,7 +240,8 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerClassicProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ContainerInspect", mock.Anything, mock.Anything).Return(tt.containerSpec, tt.err)
@@ -271,6 +284,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container with name \"nginx\" was not found",
 			},
@@ -288,6 +302,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr: false,
@@ -297,7 +312,8 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerClassicProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).Return(tt.err)
@@ -340,6 +356,7 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "container with name \"nginx\" was not found",
 			},
@@ -357,6 +374,7 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr: false,
@@ -366,7 +384,8 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerClassicProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ContainerStart", mock.Anything, mock.Anything, mock.Anything).Return(tt.err)

--- a/app/providers/docker_swarm_test.go
+++ b/app/providers/docker_swarm_test.go
@@ -45,6 +45,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 1),
@@ -68,6 +69,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "ambiguous service names found for \"nginx\" (STACK1_nginx, STACK2_nginx)",
 			},
@@ -93,6 +95,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 1),
@@ -116,6 +119,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx (STACK1_nginx)",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("STACK1_nginx", 1),
@@ -138,6 +142,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "swarm service is not in \"replicated\" mode",
 			},
@@ -148,7 +153,8 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerSwarmProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)
@@ -200,6 +206,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 0),
@@ -223,6 +230,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "ambiguous service names found for \"nginx\" (STACK1_nginx, STACK2_nginx)",
 			},
@@ -248,6 +256,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 0),
@@ -271,6 +280,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx (STACK1_nginx)",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("STACK1_nginx", 0),
@@ -293,6 +303,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "swarm service is not in \"replicated\" mode",
 			},
@@ -303,7 +314,8 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerSwarmProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)
@@ -350,6 +362,7 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 1,
+				DesiredReplicas: 1,
 				Status:          instance.Ready,
 			},
 			wantErr: false,
@@ -368,6 +381,7 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr: false,
@@ -386,6 +400,7 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx (STACK_nginx)",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.NotReady,
 			},
 			wantErr: false,
@@ -404,6 +419,7 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "nginx",
 				CurrentReplicas: 0,
+				DesiredReplicas: 1,
 				Status:          instance.Unrecoverable,
 				Message:         "swarm service is not in \"replicated\" mode",
 			},
@@ -413,7 +429,8 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &DockerSwarmProvider{
-				Client: tt.fields.Client,
+				Client:          tt.fields.Client,
+				desiredReplicas: 1,
 			}
 
 			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)

--- a/app/providers/kubernetes_test.go
+++ b/app/providers/kubernetes_test.go
@@ -36,6 +36,7 @@ func TestKubernetesProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "deployment_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -53,6 +54,7 @@ func TestKubernetesProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "statefulset_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -70,6 +72,7 @@ func TestKubernetesProvider_Start(t *testing.T) {
 			want: instance.State{
 				Name:            "gateway_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.Unrecoverable,
 				Message:         "unsupported kind \"gateway\" must be one of \"deployment\", \"statefulset\"",
 			},
@@ -131,6 +134,7 @@ func TestKubernetesProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "deployment_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -148,6 +152,7 @@ func TestKubernetesProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "statefulset_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -165,6 +170,7 @@ func TestKubernetesProvider_Stop(t *testing.T) {
 			want: instance.State{
 				Name:            "gateway_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.Unrecoverable,
 				Message:         "unsupported kind \"gateway\" must be one of \"deployment\", \"statefulset\"",
 			},
@@ -226,6 +232,7 @@ func TestKubernetesProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "deployment_default_nginx_2",
 				CurrentReplicas: 2,
+				DesiredReplicas: 2,
 				Status:          instance.Ready,
 			},
 			data: data{
@@ -242,6 +249,7 @@ func TestKubernetesProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "deployment_default_nginx_2",
 				CurrentReplicas: 1,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -258,6 +266,7 @@ func TestKubernetesProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "statefulset_default_nginx_2",
 				CurrentReplicas: 2,
+				DesiredReplicas: 2,
 				Status:          instance.Ready,
 			},
 			data: data{
@@ -274,6 +283,7 @@ func TestKubernetesProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "statefulset_default_nginx_2",
 				CurrentReplicas: 1,
+				DesiredReplicas: 2,
 				Status:          instance.NotReady,
 			},
 			data: data{
@@ -290,6 +300,7 @@ func TestKubernetesProvider_GetState(t *testing.T) {
 			want: instance.State{
 				Name:            "gateway_default_nginx_2",
 				CurrentReplicas: 0,
+				DesiredReplicas: 2,
 				Status:          instance.Unrecoverable,
 				Message:         "unsupported kind \"gateway\" must be one of \"deployment\", \"statefulset\"",
 			},

--- a/app/sessions/sessions_manager.go
+++ b/app/sessions/sessions_manager.go
@@ -129,6 +129,7 @@ func (s *SessionsManager) requestSessionInstance(name string, duration time.Dura
 
 		requestState.Name = state.Name
 		requestState.CurrentReplicas = state.CurrentReplicas
+		requestState.DesiredReplicas = state.DesiredReplicas
 		requestState.Status = state.Status
 		requestState.Message = state.Message
 		log.Debugf("status for %s=%s", name, requestState.Status)
@@ -143,6 +144,7 @@ func (s *SessionsManager) requestSessionInstance(name string, duration time.Dura
 
 		requestState.Name = state.Name
 		requestState.CurrentReplicas = state.CurrentReplicas
+		requestState.DesiredReplicas = state.DesiredReplicas
 		requestState.Status = state.Status
 		requestState.Message = state.Message
 		log.Debugf("status for %s=%s", name, requestState.Status)


### PR DESCRIPTION
For now only the `Kubernetes` provider benefits from this improvement as `Docker` and `Swarm` have hardcoded 1 value