### PR TITLE
Feature/add-docker-event-listener

### DIFF
--- a/app/providers/docker_classic_test.go
+++ b/app/providers/docker_classic_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -8,12 +9,13 @@ import (
 	"github.com/acouvreur/sablier/app/instance"
 	"github.com/acouvreur/sablier/app/providers/mocks"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestDockerClassicProvider_GetState(t *testing.T) {
 	type fields struct {
-		Client *mocks.ContainerAPIClientMock
+		Client *mocks.DockerAPIClientMock
 	}
 	type args struct {
 		name string
@@ -30,7 +32,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx created container state",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -47,7 +49,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx running container state without healthcheck",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -64,7 +66,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx running container state with \"starting\" health",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -81,7 +83,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx running container state with \"unhealthy\" health",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -99,7 +101,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx running container state with \"healthy\" health",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -116,7 +118,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx paused container state",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -133,7 +135,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx restarting container state",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -150,7 +152,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx removing container state",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -167,7 +169,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx exited container state with status code 0",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -184,7 +186,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx exited container state with status code 137",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -202,7 +204,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "nginx dead container state",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -220,7 +222,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		{
 			name: "container inspect has an error",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -260,7 +262,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 
 func TestDockerClassicProvider_Stop(t *testing.T) {
 	type fields struct {
-		Client *mocks.ContainerAPIClientMock
+		Client *mocks.DockerAPIClientMock
 	}
 	type args struct {
 		name string
@@ -276,7 +278,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 		{
 			name: "container stop has an error",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -294,7 +296,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 		{
 			name: "container stop as expected",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -332,7 +334,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 
 func TestDockerClassicProvider_Start(t *testing.T) {
 	type fields struct {
-		Client *mocks.ContainerAPIClientMock
+		Client *mocks.DockerAPIClientMock
 	}
 	type args struct {
 		name string
@@ -348,7 +350,7 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 		{
 			name: "container start has an error",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -366,7 +368,7 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 		{
 			name: "container start as expected",
 			fields: fields{
-				Client: mocks.NewContainerAPIClientMock(),
+				Client: mocks.NewDockerAPIClientMock(),
 			},
 			args: args{
 				name: "nginx",
@@ -397,6 +399,46 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DockerClassicProvider.Start() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDockerClassicProvider_NotifyInsanceStopped(t *testing.T) {
+	tests := []struct {
+		name   string
+		want   []string
+		events []events.Message
+		errors []error
+	}{
+		{
+			name: "container nginx is stopped",
+			want: []string{"nginx"},
+			events: []events.Message{
+				mocks.ContainerStoppedEvent("nginx"),
+			},
+			errors: []error{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &DockerClassicProvider{
+				Client:          mocks.NewDockerAPIClientMockWithEvents(tt.events, tt.errors),
+				desiredReplicas: 1,
+			}
+
+			instanceC := make(chan string)
+
+			provider.NotifyInsanceStopped(context.Background(), instanceC)
+
+			var got []string
+
+			for i := range instanceC {
+				got = append(got, i)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NotifyInsanceStopped() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/app/providers/docker_swarm.go
+++ b/app/providers/docker_swarm.go
@@ -137,3 +137,6 @@ func (provider *DockerSwarmProvider) getInstanceName(name string, service swarm.
 
 	return fmt.Sprintf("%s (%s)", name, service.Spec.Name)
 }
+
+func (provider *DockerSwarmProvider) NotifyInsanceStopped(ctx context.Context, instance chan string) {
+}

--- a/app/providers/kubernetes.go
+++ b/app/providers/kubernetes.go
@@ -165,3 +165,6 @@ func (provider *KubernetesProvider) getStatefulsetState(config *Config) (instanc
 
 	return instance.NotReadyInstanceState(config.OriginalName, int(ss.Status.ReadyReplicas), int(config.Replicas))
 }
+
+func (provider *KubernetesProvider) NotifyInsanceStopped(ctx context.Context, instance chan string) {
+}

--- a/app/providers/provider.go
+++ b/app/providers/provider.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/acouvreur/sablier/app/instance"
@@ -11,6 +12,8 @@ type Provider interface {
 	Start(name string) (instance.State, error)
 	Stop(name string) (instance.State, error)
 	GetState(name string) (instance.State, error)
+
+	NotifyInsanceStopped(ctx context.Context, instance chan string)
 }
 
 func NewProvider(config config.Provider) (Provider, error) {

--- a/app/sessions/mocks/provider_mock.go
+++ b/app/sessions/mocks/provider_mock.go
@@ -1,0 +1,68 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/acouvreur/sablier/app/instance"
+	"github.com/acouvreur/sablier/app/providers"
+	"github.com/acouvreur/sablier/pkg/tinykv"
+	"github.com/stretchr/testify/mock"
+)
+
+type ProviderMock struct {
+	stoppedInstances []string
+
+	wg sync.WaitGroup
+
+	providers.Provider
+	mock.Mock
+}
+
+func NewProviderMock(stoppedInstances []string) *ProviderMock {
+	return &ProviderMock{
+		stoppedInstances: stoppedInstances,
+	}
+}
+
+func (provider *ProviderMock) NotifyInsanceStopped(ctx context.Context, instance chan string) {
+	go func() {
+		defer close(instance)
+		for i := 0; i < len(provider.stoppedInstances); i++ {
+			instance <- provider.stoppedInstances[i]
+		}
+		provider.wg.Done()
+	}()
+}
+
+func (provider *ProviderMock) Add(count int) {
+	provider.wg.Add(count)
+}
+
+func (provider *ProviderMock) Wait() {
+	provider.wg.Wait()
+}
+
+type KVMock[T any] struct {
+	wg sync.WaitGroup
+
+	tinykv.KV[T]
+	mock.Mock
+}
+
+func NewKVMock() *KVMock[instance.State] {
+	return &KVMock[instance.State]{}
+}
+
+func (kv *KVMock[T]) Delete(k string) {
+	kv.Mock.Called(k)
+	kv.wg.Done()
+}
+
+func (kv *KVMock[T]) Add(count int) {
+	kv.wg.Add(count)
+}
+
+func (kv *KVMock[T]) Wait() {
+	kv.wg.Wait()
+}

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -57,6 +57,7 @@ type entry[T any] struct {
 
 // KV is a registry for values (like/is a concurrent map) with timeout and sliding timeout
 type KV[T any] interface {
+	Delete(k string)
 	Get(k string) (v T, ok bool)
 	Keys() (keys []string)
 	Values() (values []T)
@@ -102,6 +103,13 @@ func New[T any](expirationInterval time.Duration, onExpire ...func(k string, v T
 // Stop stops the goroutine
 func (kv *store[T]) Stop() {
 	kv.stopOnce.Do(func() { close(kv.stop) })
+}
+
+// Delete deletes an entry
+func (kv *store[T]) Delete(k string) {
+	kv.mx.Lock()
+	defer kv.mx.Unlock()
+	delete(kv.kv, k)
 }
 
 func (kv *store[T]) Get(k string) (T, bool) {

--- a/pkg/tinykv/tinykv_test.go
+++ b/pkg/tinykv/tinykv_test.go
@@ -201,6 +201,25 @@ func Test03(t *testing.T) {
 	assert.WithinDuration(putAt, putAt.Add(<-elapsed), time.Millisecond*60)
 }
 
+func Test04(t *testing.T) {
+	assert := assert.New(t)
+	kv := New(
+		time.Millisecond*10,
+		func(k string, v interface{}) {
+			t.Fatal(k, v)
+		})
+
+	err := kv.Put("1", 1, time.Millisecond*10000)
+	assert.NoError(err)
+	<-time.After(time.Millisecond * 50)
+	kv.Delete("1")
+	kv.Delete("1")
+
+	<-time.After(time.Millisecond * 100)
+	_, ok := kv.Get("1")
+	assert.False(ok)
+}
+
 func Test05(t *testing.T) {
 	assert := assert.New(t)
 	N := 10000


### PR DESCRIPTION
When a container is shutdown manually while it's registered as `ready` in Sablier it will remove it from the store.
Meaning externally events are now handled for docker.

WIP Commit