### PR TITLE
Fix/set-swarm-to-strict-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,6 @@ http:
 
 #### Traefik with Docker Swarm
 
-- The value from the `names` section will do a strict match if possible, if it is not found it will match by suffix only if there's one match.
-  - `names=nginx` matches `nginx` from `MYSTACK_nginx` and `nginx` services
-  - `names=nginx` matches `MYSTACK_nginx` from `MYSTACK_nginx` and `nginx-2` services
-
 ⚠️ Limitations
 
 - Traefik will evict the service from its pool as soon as the service is 0/0. You must add the [`traefik.docker.lbswarm`](https://doc.traefik.io/traefik/routing/providers/docker/#traefikdockerlbswarm) label.

--- a/app/providers/docker_swarm.go
+++ b/app/providers/docker_swarm.go
@@ -106,27 +106,11 @@ func (provider *DockerSwarmProvider) getServiceByName(name string, ctx context.C
 		return nil, fmt.Errorf(fmt.Sprintf("service with name %s was not found", name))
 	}
 
-	suffixMatches := make([]swarm.Service, 0)
-	suffixMatchNames := make([]string, 0)
-
 	for _, service := range services {
 		// Exact match
 		if service.Spec.Name == name {
 			return &service, nil
-		} else if strings.HasSuffix(service.Spec.Name, name) {
-			suffixMatches = append(suffixMatches, service)
-			suffixMatchNames = append(suffixMatchNames, service.Spec.Name)
-		} else {
-			log.Warnf("service %s was ignored because it did not match %s exactly or on suffix", service.Spec.Name, name)
 		}
-	}
-
-	if len(suffixMatches) > 1 {
-		return nil, fmt.Errorf("ambiguous service names found for \"%s\" (%s)", name, strings.Join(suffixMatchNames, ", "))
-	}
-
-	if len(suffixMatches) == 1 {
-		return &suffixMatches[0], nil
 	}
 
 	return nil, fmt.Errorf(fmt.Sprintf("service %s was not found because it did not match exactly or on suffix", name))

--- a/app/providers/docker_swarm_test.go
+++ b/app/providers/docker_swarm_test.go
@@ -47,28 +47,6 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "ambiguous service name",
-			args: args{
-				name: "nginx",
-			},
-			serviceList: []swarm.Service{
-				mocks.ServiceReplicated("STACK1_nginx", 0),
-				mocks.ServiceReplicated("STACK2_nginx", 0),
-			},
-			response: types.ServiceUpdateResponse{
-				Warnings: []string{},
-			},
-			want: instance.State{
-				Name:            "nginx",
-				CurrentReplicas: 0,
-				DesiredReplicas: 1,
-				Status:          instance.Unrecoverable,
-				Message:         "ambiguous service names found for \"nginx\" (STACK1_nginx, STACK2_nginx)",
-			},
-			wantService: mocks.ServiceReplicated("nginx", 1),
-			wantErr:     true,
-		},
-		{
 			name: "exact match service name",
 			args: args{
 				name: "nginx",
@@ -88,27 +66,6 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 1),
-			wantErr:     false,
-		},
-		{
-			name: "service match on suffix",
-			args: args{
-				name: "nginx",
-			},
-			serviceList: []swarm.Service{
-				mocks.ServiceReplicated("STACK1_nginx", 0),
-				mocks.ServiceReplicated("STACK2_nginx-2", 0),
-			},
-			response: types.ServiceUpdateResponse{
-				Warnings: []string{},
-			},
-			want: instance.State{
-				Name:            "nginx (STACK1_nginx)",
-				CurrentReplicas: 0,
-				DesiredReplicas: 1,
-				Status:          instance.NotReady,
-			},
-			wantService: mocks.ServiceReplicated("STACK1_nginx", 1),
 			wantErr:     false,
 		},
 		{
@@ -190,28 +147,6 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "ambiguous service name",
-			args: args{
-				name: "nginx",
-			},
-			serviceList: []swarm.Service{
-				mocks.ServiceReplicated("STACK1_nginx", 1),
-				mocks.ServiceReplicated("STACK2_nginx", 1),
-			},
-			response: types.ServiceUpdateResponse{
-				Warnings: []string{},
-			},
-			want: instance.State{
-				Name:            "nginx",
-				CurrentReplicas: 0,
-				DesiredReplicas: 1,
-				Status:          instance.Unrecoverable,
-				Message:         "ambiguous service names found for \"nginx\" (STACK1_nginx, STACK2_nginx)",
-			},
-			wantService: mocks.ServiceReplicated("nginx", 1),
-			wantErr:     true,
-		},
-		{
 			name: "exact match service name",
 			args: args{
 				name: "nginx",
@@ -231,27 +166,6 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 				Status:          instance.NotReady,
 			},
 			wantService: mocks.ServiceReplicated("nginx", 0),
-			wantErr:     false,
-		},
-		{
-			name: "service match on suffix",
-			args: args{
-				name: "nginx",
-			},
-			serviceList: []swarm.Service{
-				mocks.ServiceReplicated("STACK1_nginx", 1),
-				mocks.ServiceReplicated("STACK2_nginx-2", 1),
-			},
-			response: types.ServiceUpdateResponse{
-				Warnings: []string{},
-			},
-			want: instance.State{
-				Name:            "nginx (STACK1_nginx)",
-				CurrentReplicas: 0,
-				DesiredReplicas: 1,
-				Status:          instance.NotReady,
-			},
-			wantService: mocks.ServiceReplicated("STACK1_nginx", 0),
 			wantErr:     false,
 		},
 		{
@@ -336,22 +250,6 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			},
 			want: instance.State{
 				Name:            "nginx",
-				CurrentReplicas: 0,
-				DesiredReplicas: 1,
-				Status:          instance.NotReady,
-			},
-			wantErr: false,
-		},
-		{
-			name: "nginx service is not ready",
-			args: args{
-				name: "nginx",
-			},
-			serviceList: []swarm.Service{
-				mocks.ServiceNotReadyReplicated("STACK_nginx", 1, 0),
-			},
-			want: instance.State{
-				Name:            "nginx (STACK_nginx)",
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
 				Status:          instance.NotReady,


### PR DESCRIPTION
This could bring too much complexity. If a new service was created with exact match, it would take pecedence over the previously suffix matched service.