### PR TITLE
feat(api) Added Status API

### DIFF
--- a/app/http/routes/status.go
+++ b/app/http/routes/status.go
@@ -1,0 +1,52 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/acouvreur/sablier/app/instance"
+	"github.com/acouvreur/sablier/app/sessions"
+	"github.com/acouvreur/sablier/config"
+	"github.com/gin-gonic/gin"
+)
+
+type Status struct {
+	SessionsManager sessions.Manager
+	StrategyConfig  config.Strategy
+	SessionsConfig  config.Sessions
+}
+
+func NewStatus(sessionsManager sessions.Manager, strategyConf config.Strategy, sessionsConf config.Sessions) *Status {
+
+	status := &Status{
+		SessionsManager: sessionsManager,
+		StrategyConfig:  strategyConf,
+		SessionsConfig:  sessionsConf,
+	}
+
+	return status
+}
+
+type StatusResponse struct {
+	ManagedServices []instance.State `json:"managed_services"`
+}
+
+func (s *Status) ServeStatus(c *gin.Context) {
+	containers, _ := s.SessionsManager.GetManagedContainers()
+
+	var managedServices []instance.State
+	for _, name := range containers {
+
+		state := s.SessionsManager.GetContainerStatus(name)
+
+		if state.Error != nil {
+			c.AbortWithStatus(500)
+		}
+
+		managedServices = append(managedServices, *state.Instance)
+	}
+
+	output := StatusResponse{
+		ManagedServices: managedServices,
+	}
+	c.JSON(http.StatusOK, output)
+}

--- a/app/http/server.go
+++ b/app/http/server.go
@@ -33,14 +33,13 @@ func Start(serverConf config.Server, strategyConf config.Strategy, sessionsConf 
 			api.GET("/strategies/dynamic", strategy.ServeDynamic)
 			api.GET("/strategies/dynamic/themes", strategy.ServeDynamicThemes)
 			api.GET("/strategies/blocking", strategy.ServeBlocking)
+			status := routes.NewStatus(sessionManager, strategyConf, sessionsConf)
+			api.GET("/status", status.ServeStatus)
 		}
 		health := routes.Health{}
 		health.SetDefaults()
 		health.WithContext(ctx)
 		base.GET("/health", health.ServeHTTP)
-
-		status := routes.NewStatus(sessionManager, strategyConf, sessionsConf)
-		base.GET("/status", status.ServeStatus)
 	}
 
 	srv := &http.Server{

--- a/app/http/server.go
+++ b/app/http/server.go
@@ -38,6 +38,9 @@ func Start(serverConf config.Server, strategyConf config.Strategy, sessionsConf 
 		health.SetDefaults()
 		health.WithContext(ctx)
 		base.GET("/health", health.ServeHTTP)
+
+		status := routes.NewStatus(sessionManager, strategyConf, sessionsConf)
+		base.GET("/status", status.ServeStatus)
 	}
 
 	srv := &http.Server{

--- a/app/instance/instance.go
+++ b/app/instance/instance.go
@@ -1,17 +1,23 @@
 package instance
 
-import log "github.com/sirupsen/logrus"
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
 
 var Ready = "ready"
 var NotReady = "not-ready"
 var Unrecoverable = "unrecoverable"
 
 type State struct {
-	Name            string `json:"name"`
-	CurrentReplicas int    `json:"currentReplicas"`
-	DesiredReplicas int    `json:"desiredReplicas"`
-	Status          string `json:"status"`
-	Message         string `json:"message,omitempty"`
+	Name            string        `json:"name"`
+	CurrentReplicas int           `json:"currentReplicas"`
+	DesiredReplicas int           `json:"desiredReplicas"`
+	Status          string        `json:"status"`
+	Message         string        `json:"message,omitempty"`
+	ExpiresAt       time.Time     `json:"expires_on"`
+	ExpiresAfter    time.Duration `json:"expires_in"`
 }
 
 func (instance State) IsReady() bool {

--- a/app/instance/instance.go
+++ b/app/instance/instance.go
@@ -17,7 +17,7 @@ type State struct {
 	Status          string        `json:"status"`
 	Message         string        `json:"message,omitempty"`
 	ExpiresAt       time.Time     `json:"expires_on"`
-	ExpiresAfter    time.Duration `json:"expires_in"`
+	ExpiresIn       time.Duration `json:"expires_in"`
 }
 
 func (instance State) IsReady() bool {

--- a/app/providers/docker_classic.go
+++ b/app/providers/docker_classic.go
@@ -64,7 +64,7 @@ func (provider *DockerClassicProvider) GetGroups() (map[string][]string, error) 
 	return groups, nil
 }
 
-func (provider *DockerClassicProvider) GetMangedContainers() ([]string, error) {
+func (provider *DockerClassicProvider) GetManagedContainers() ([]string, error) {
 	ctx := context.Background()
 
 	filters := filters.NewArgs()

--- a/app/providers/docker_classic.go
+++ b/app/providers/docker_classic.go
@@ -64,6 +64,30 @@ func (provider *DockerClassicProvider) GetGroups() (map[string][]string, error) 
 	return groups, nil
 }
 
+func (provider *DockerClassicProvider) GetMangedContainers() ([]string, error) {
+	ctx := context.Background()
+
+	filters := filters.NewArgs()
+	filters.Add("label", fmt.Sprintf("%s=true", enableLabel))
+
+	containers, err := provider.Client.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: filters,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var output []string
+
+	for _, container := range containers {
+		output = append(output, strings.TrimPrefix(container.Names[0], "/"))
+	}
+
+	return output, nil
+}
+
 func (provider *DockerClassicProvider) Start(name string) (instance.State, error) {
 	ctx := context.Background()
 

--- a/app/providers/docker_swarm.go
+++ b/app/providers/docker_swarm.go
@@ -111,7 +111,7 @@ func (provider *DockerSwarmProvider) GetGroup(group string) []string {
 	return containers.([]string)
 }
 
-func (provider *DockerSwarmProvider) GetMangedContainers() ([]string, error) {
+func (provider *DockerSwarmProvider) GetManagedContainers() ([]string, error) {
 	ctx := context.Background()
 
 	filters := filters.NewArgs()

--- a/app/providers/docker_swarm.go
+++ b/app/providers/docker_swarm.go
@@ -111,6 +111,29 @@ func (provider *DockerSwarmProvider) GetGroup(group string) []string {
 	return containers.([]string)
 }
 
+func (provider *DockerSwarmProvider) GetMangedContainers() ([]string, error) {
+	ctx := context.Background()
+
+	filters := filters.NewArgs()
+	filters.Add("label", fmt.Sprintf("%s=true", enableLabel))
+
+	services, err := provider.Client.ServiceList(ctx, types.ServiceListOptions{
+		Filters: filters,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var output []string
+
+	for _, service := range services {
+		output = append(output, service.Spec.Name)
+	}
+
+	return output, nil
+}
+
 func (provider *DockerSwarmProvider) GetState(name string) (instance.State, error) {
 	ctx := context.Background()
 

--- a/app/providers/kubernetes.go
+++ b/app/providers/kubernetes.go
@@ -123,6 +123,27 @@ func (provider *KubernetesProvider) GetGroups() (map[string][]string, error) {
 	return groups, nil
 }
 
+func (provider *KubernetesProvider) GetMangedContainers() ([]string, error) {
+	ctx := context.Background()
+
+	deployments, err := provider.Client.AppsV1().Deployments(core_v1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: enableLabel,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var output []string
+
+	for _, deployment := range deployments.Items {
+		name := fmt.Sprintf("%s_%s_%s_%d", "deployment", deployment.Namespace, deployment.Name, 1)
+		output = append(output, name)
+	}
+
+	return output, nil
+}
+
 func (provider *KubernetesProvider) scale(config *Config, replicas int32) (instance.State, error) {
 	ctx := context.Background()
 

--- a/app/providers/kubernetes.go
+++ b/app/providers/kubernetes.go
@@ -123,7 +123,7 @@ func (provider *KubernetesProvider) GetGroups() (map[string][]string, error) {
 	return groups, nil
 }
 
-func (provider *KubernetesProvider) GetMangedContainers() ([]string, error) {
+func (provider *KubernetesProvider) GetManagedContainers() ([]string, error) {
 	ctx := context.Background()
 
 	deployments, err := provider.Client.AppsV1().Deployments(core_v1.NamespaceAll).List(ctx, metav1.ListOptions{

--- a/app/providers/provider.go
+++ b/app/providers/provider.go
@@ -17,6 +17,7 @@ type Provider interface {
 	Stop(name string) (instance.State, error)
 	GetState(name string) (instance.State, error)
 	GetGroups() (map[string][]string, error)
+	GetMangedContainers() ([]string, error)
 
 	NotifyInstanceStopped(ctx context.Context, instance chan<- string)
 }

--- a/app/providers/provider.go
+++ b/app/providers/provider.go
@@ -17,7 +17,7 @@ type Provider interface {
 	Stop(name string) (instance.State, error)
 	GetState(name string) (instance.State, error)
 	GetGroups() (map[string][]string, error)
-	GetMangedContainers() ([]string, error)
+	GetManagedContainers() ([]string, error)
 
 	NotifyInstanceStopped(ctx context.Context, instance chan<- string)
 }

--- a/app/sablier.go
+++ b/app/sablier.go
@@ -39,7 +39,7 @@ func Start(conf config.Config) error {
 		return err
 	}
 
-	sessionsManager := sessions.NewSessionsManager(store, provider)
+	sessionsManager := sessions.NewSessionsManager(store, provider, conf)
 	defer sessionsManager.Stop()
 
 	if storage.Enabled() {

--- a/app/sessions/sessions_manager.go
+++ b/app/sessions/sessions_manager.go
@@ -277,7 +277,7 @@ func (s *SessionsManager) RequestReadySessionGroup(ctx context.Context, group st
 
 func (s *SessionsManager) GetManagedContainers() ([]string, error) {
 
-	output, err := s.provider.GetMangedContainers()
+	output, err := s.provider.GetManagedContainers()
 
 	if err != nil {
 		return nil, fmt.Errorf("Error getting list of managed containers")

--- a/app/sessions/sessions_manager.go
+++ b/app/sessions/sessions_manager.go
@@ -301,7 +301,7 @@ func (s *SessionsManager) GetContainerStatus(name string) *InstanceState {
 	storeState, exists := s.store.GetWithTimeout(name)
 	if exists {
 		instance.Instance.ExpiresAt = storeState.ExpiresAt
-		instance.Instance.ExpiresAfter = storeState.ExpiresAfter
+		instance.Instance.ExpiresIn = storeState.ExpiresIn
 	}
 
 	return instance

--- a/app/sessions/sessions_manager_test.go
+++ b/app/sessions/sessions_manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/acouvreur/sablier/app/instance"
 	"github.com/acouvreur/sablier/app/sessions/mocks"
+	"github.com/acouvreur/sablier/config"
 	"github.com/stretchr/testify/mock"
 	"gotest.tools/v3/assert"
 )
@@ -104,11 +105,13 @@ func TestNewSessionsManagerEvents(t *testing.T) {
 			provider := mocks.NewProviderMockWithStoppedInstancesEvents(tt.stoppedInstances)
 			provider.Add(1)
 
+			conf := config.NewConfig()
+
 			kv := mocks.NewKVMock()
 			kv.Add(len(tt.stoppedInstances))
 			kv.Mock.On("Delete", mock.AnythingOfType("string")).Return()
 
-			NewSessionsManager(kv, provider)
+			NewSessionsManager(kv, provider, conf)
 
 			// The provider watches notifications from a Goroutine, must wait
 			provider.Wait()

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -13,9 +13,9 @@ type timeout struct {
 }
 
 type EntityWithTimeout struct {
-	Value        any
-	ExpiresAt    time.Time
-	ExpiresAfter time.Duration
+	Value     any
+	ExpiresAt time.Time
+	ExpiresIn time.Duration
 }
 
 func newTimeout(
@@ -154,17 +154,18 @@ func (kv *store[T]) GetWithTimeout(k string) (EntityWithTimeout, bool) {
 	var expiresAfter time.Duration
 
 	if e.timeout != nil {
+		diff := time.Since(e.expiresAt) * -1
 		expiresAt = e.expiresAt
-		expiresAfter = e.expiresAfter
+		expiresAfter = time.Duration(diff.Seconds())
 	} else {
 		expiresAt = time.Time{}
 		expiresAfter = 0
 	}
 
 	entity := EntityWithTimeout{
-		Value:        e.value,
-		ExpiresAt:    expiresAt,
-		ExpiresAfter: expiresAfter,
+		Value:     e.value,
+		ExpiresAt: expiresAt,
+		ExpiresIn: expiresAfter,
 	}
 
 	return entity, true


### PR DESCRIPTION
I have recently picked up learning Go and trying to learn to contribute back into open source. And thought that Sablier would be a good project to get involved in.

I have been putting in the early stages of a status page, which intends to show the status of the services Sablier manages, along with useful information about those services, mainly, the status, expiration time, and remaining time.

I had to make quite a few updates across the solution. I have documented the rationale below

* Gin - Updates to include status page. The response payload is designed in a way so that it can be extended with global configs. 
* KV store - This required an update of a new method to be able to get a value along with expiration information 
* Instance - Updated structs to store additional state data
* Providers - Updated providers with a new function to get the list of managed containers, using label enable = true
* Session Manager - Few methods to get the service status

Output:
Calling `/api/status` :

```json
{
  "managed_services": [
    {
      "name": "whoami-secondary",
      "currentReplicas": 1,
      "desiredReplicas": 1,
      "status": "ready",
      "expires_on": "0001-01-01T00:00:00Z",
      "expires_in": 0
    },
    {
      "name": "whoami-primary",
      "currentReplicas": 0,
      "desiredReplicas": 1,
      "status": "unrecoverable",
      "message": "ready"
      "expires_on": "2023-08-08T11:57:59.3412899Z",
      "expires_in": 260
    }
  ]
}
```

Potential non-blocking issues:
* The status could be refined a bit better depending on if the container is up or down
* If a service hasn't been hit for the first time, it shows as ready with no expiry (see whoami-secondary). This has been documented in https://github.com/acouvreur/sablier/issues/153, and could be a quick fix on startup.

I haven't used Go before, nor any of the libraries such as Gin, so some good feedback and advice would be helpful.  I have tired to stick close to the  format in the project.