### PR TITLE
Fix issue with loading page not showing in Traefik for h2 connections

### DIFF
--- a/plugins/traefik/main.go
+++ b/plugins/traefik/main.go
@@ -46,6 +46,5 @@ func (sm *SablierMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request
 
 func forward(resp *http.Response, rw http.ResponseWriter) {
 	rw.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-	rw.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
 	io.Copy(rw, resp.Body)
 }


### PR DESCRIPTION
I continued my investigation of issue https://github.com/acouvreur/sablier/issues/165 and I discovered that when making a working request these are the headers seen by cURL:
```
curl -v http://localhost:8080/dynamic/whoami
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /dynamic/whoami HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: text/html
< Date: Sun, 27 Aug 2023 00:23:52 GMT
< Transfer-Encoding: chunked
< 
```
Note that `Content-Length` is not present. https://stackoverflow.com/questions/75091383/why-does-golang-http-responsewriter-auto-add-content-length-if-its-no-more-than talks about this and describes what's going on.

Apparently this is not an issue for HTTP/1.1 connections, which are used by cURL and the browsers when there is no TLS involved. 
When the request is HTTPs cURL and browsers prefer to use h2, which I guess handle headers in a different ways.

If I force cURL to use HTTP1.1 I get the loading page even for TLS requests, so this is definitely and issue related to h2.
Anyway, `Content-Length` is never explicitly set in [`serveDynamic`](https://github.com/acouvreur/sablier/blob/beta/app/http/routes/strategies.go#L51:L100) and loading pages tend to be above the threshold so I think not propagating it is the right fix for the issue.