### PR TITLE
fix(providers/kubernetes): Added QPS and Burst tweaks for client-side throttling

### DIFF
--- a/app/providers/kubernetes.go
+++ b/app/providers/kubernetes.go
@@ -12,6 +12,8 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 
 	"github.com/acouvreur/sablier/app/instance"
+	providerConfig "github.com/acouvreur/sablier/config"
+	log "github.com/sirupsen/logrus"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -60,12 +62,18 @@ type KubernetesProvider struct {
 	Client kubernetes.Interface
 }
 
-func NewKubernetesProvider() (*KubernetesProvider, error) {
-	config, err := rest.InClusterConfig()
+func NewKubernetesProvider(providerConfig providerConfig.Kubernetes) (*KubernetesProvider, error) {
+	kubeclientConfig, err := rest.InClusterConfig()
+
+	kubeclientConfig.QPS = providerConfig.QPS
+	kubeclientConfig.Burst = providerConfig.Burst
+
+	log.Debug(fmt.Sprintf("Provider configuration:  QPS=%v, Burst=%v", kubeclientConfig.QPS, kubeclientConfig.Burst))
+
 	if err != nil {
 		return nil, err
 	}
-	client, err := kubernetes.NewForConfig(config)
+	client, err := kubernetes.NewForConfig(kubeclientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/app/providers/provider.go
+++ b/app/providers/provider.go
@@ -28,7 +28,7 @@ func NewProvider(config config.Provider) (Provider, error) {
 	case config.Name == "docker":
 		return NewDockerClassicProvider()
 	case config.Name == "kubernetes":
-		return NewKubernetesProvider()
+		return NewKubernetesProvider(config.Kubernetes)
 	}
 	return nil, fmt.Errorf("unimplemented provider %s", config.Name)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,10 @@ It provides an integrations with multiple reverse proxies and different loading 
 	// Provider flags
 	startCmd.Flags().StringVar(&conf.Provider.Name, "provider.name", "docker", fmt.Sprintf("Provider to use to manage containers %v", config.GetProviders()))
 	viper.BindPFlag("provider.name", startCmd.Flags().Lookup("provider.name"))
+	startCmd.Flags().Float32Var(&conf.Provider.Kubernetes.QPS, "provider.kubernetes.QPS", 5, fmt.Sprintf("QPS limit for K8S API access client-side throttling"))
+	viper.BindPFlag("provider.kubernetes.qps", startCmd.Flags().Lookup("provider.kubernetes.qps"))
+	startCmd.Flags().IntVar(&conf.Provider.Kubernetes.Burst, "provider.kubernetes.burst", 10, fmt.Sprintf("Maximum burst for K8S API acees client-side throttling"))
+	viper.BindPFlag("provider.kubernetes.burst", startCmd.Flags().Lookup("provider.kubernetes.Burst"))
 	// Server flags
 	startCmd.Flags().IntVar(&conf.Server.Port, "server.port", 10000, "The server port to use")
 	viper.BindPFlag("server.port", startCmd.Flags().Lookup("server.port"))

--- a/config/provider.go
+++ b/config/provider.go
@@ -7,7 +7,15 @@ import (
 // Provider holds the provider description
 // It can be either docker, swarm or kubernetes
 type Provider struct {
-	Name string `mapstructure:"NAME" yaml:"provider,omitempty"`
+	Name       string `mapstructure:"NAME" yaml:"provider,omitempty"`
+	Kubernetes Kubernetes
+}
+
+type Kubernetes struct {
+	//QPS limit for  K8S API access client-side throttle
+	QPS float32 `mapstructure:"QPS" yaml:"QPS" default:"5"`
+	//Maximum burst for client-side throttle
+	Burst int `mapstructure:"BURST" yaml:"Burst" default:"10"`
 }
 
 var providers = []string{"docker", "swarm", "kubernetes"}
@@ -15,6 +23,10 @@ var providers = []string{"docker", "swarm", "kubernetes"}
 func NewProviderConfig() Provider {
 	return Provider{
 		Name: "docker",
+		Kubernetes: Kubernetes{
+			QPS:   5,
+			Burst: 10,
+		},
 	}
 }
 


### PR DESCRIPTION
Hello

The reasoning behind this PR is to enable the adjustment of QPS and Burst configuration parameters in the client-go library.

This will help avoid constant throttling issues when dealing with over 100 K8S deployments. The default values are insufficient for such a large number of deployments.

How client-side throttling works:
// NewTokenBucketRateLimiter creates a rate limiter which implements a token bucket approach.
// The rate limiter allows bursts of up to 'burst' to exceed the QPS, while still maintaining a
// smoothed qps rate of 'qps'.
// The bucket is initially filled with 'burst' tokens, and refills at a rate of 'qps'.
// The maximum number of tokens in the bucket is capped at 'burst'.

It is a new PR with clearer diff with beta branch, instead of broken #178 
I hope that working with that Pull Request will be more convenient