### PR TITLE
fix(nginx): blocking strategy correctly supports groups

### DIFF
--- a/plugins/nginx/njs/sablier.js
+++ b/plugins/nginx/njs/sablier.js
@@ -102,7 +102,6 @@ function buildRequest(c) {
  function createBlockingUrl(config) {
   const url = `${config.sablierUrl}/api/strategies/blocking`
   const query = { 
-    names: config.names.split(",").map(name => name.trim()),
     session_duration: config.sessionDuration,
     timeout:config.timeout,
   };


### PR DESCRIPTION
When supplying group, it still tried to split the names.

Fixes #244