### PR TITLE
feat(charts): sablier helm chart for kube deployement

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,12 @@
+---
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+chart-repos:
+helm-extra-args: --timeout 180s
+check-version-increment: false
+validate-maintainers: false
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,9 @@
+---
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+check-version-increment: false
+validate-maintainers: false
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -70,3 +70,12 @@ jobs:
           else
             echo -e '\033[0;32mDocumentation up to date\033[0m ✔'
           fi
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.9.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: |
+          namespace=sablier-$(uuidgen)
+          ct install --namespace=$namespace --config ./.github/configs/ct-install.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -1,0 +1,72 @@
+---
+name: "Lint and Test Chart"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linter-artifacthub:
+    runs-on: ubuntu-latest
+    container:
+      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ah lint
+        working-directory: ./charts
+        run: ah lint
+
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Run helm unittest
+        uses: d3adb5/helm-unittest-action@v2
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          charts: charts/sablier
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2
+
+      - name: List changed charts
+        id: list-changed
+        run: |
+          changed=$(ct --config ./.github/configs/ct-lint.yaml list-changed)
+          charts=$(echo "$changed" | tr '\n' ' ' | xargs)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed_charts=$charts" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml
+
+      - name: Run docs-testing (helm-docs)
+        id: helm-docs
+        run: |
+          ./scripts/helm-docs.sh
+          if [[ $(git diff --stat) != '' ]]; then
+            echo -e '\033[0;31mDocumentation outdated!\033[0m ❌'
+            git diff --color
+            exit 1
+          else
+            echo -e '\033[0;32mDocumentation up to date\033[0m ✔'
+          fi

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,57 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: ${{ steps.generate_token.outputs.token }}
+          CR_SKIP_EXISTING: "true"
+          CR_GENERATE_RELEASE_NOTES: "true"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Push Charts to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts
+          done

--- a/charts/sablier/Chart.yaml
+++ b/charts/sablier/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: sablier
+description: An free and open-source software to start workloads on demand and stop them after a period of inactivity.
+type: application
+version: "0.1.0"
+appVersion: 1.6.0
+deprecated: false
+sources:
+  - "https://github.com/acouvreur/sablier"
+keywords:
+  - Orchestration & Management
+maintainers:
+  - email: TODO
+    name: TODO

--- a/charts/sablier/README.md
+++ b/charts/sablier/README.md
@@ -1,0 +1,34 @@
+# sablier
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+
+An free and open-source software to start workloads on demand and stop them after a period of inactivity.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| TODO | <TODO> |  |
+
+## Source Code
+
+* <https://github.com/acouvreur/sablier>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
+| deploymentLabels | object | `{}` | Labels for all deployed Deployments |
+| deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | Deployment strategy for all deployed Deployments |
+| image.repository | string | `"acouvreur/sablier"` | Sablier image repository |
+| image.tag | string | `""` | Sablier image tag (deafult) appVersion |
+| imagePullPolicy | string | `"IfNotPresent"` | Sablier imagePullPolicy |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":10000},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Sablier livenessProbe |
+| logLevel | string | `"trace"` | Sablier log level |
+| podAnnotations | object | `{}` | Annotations for all deployed pods |
+| podLabels | object | `{}` | Labels for all deployed pods |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":10000},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | Sablier readinessProbe |
+| replicas | int | `1` | Sablier's replicas |
+| resources | object | `{}` | Resource limits and requests for sablier |
+

--- a/charts/sablier/templates/deployement.yaml
+++ b/charts/sablier/templates/deployement.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sablier-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: sablier-{{ .Release.Name }}
+{{- with .Values.deploymentLabels }}
+    {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: sablier-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: sablier-{{ .Release.Name }}
+{{- with .Values.podLabels }}
+      {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.podAnnotations }}
+      annotations:
+      {{ toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: sablier-{{ .Release.Name }}
+      containers:
+        - name: sablier
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          args: ["start", "--provider.name=kubernetes", "--logging.level={{ .Values.logLevel}}"]
+          ports:
+            - containerPort: 10000
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/sablier/templates/rbac.yaml
+++ b/charts/sablier/templates/rbac.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sablier-{{ .Release.Name }}
+rules:
+  - apiGroups:
+      - apps
+      - ""
+    resources:
+      - deployments
+      - deployments/scale
+      - statefulsets
+      - statefulsets/scale
+    verbs:
+      - patch # Scale up and down
+      - get # Retrieve info about specific dep
+      - update # Scale up and down
+      - list # Events
+      - watch # Events
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sablier-{{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sablier-{{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: sablier
+    namespace: {{ .Release.Namespace }}

--- a/charts/sablier/templates/sa.yaml
+++ b/charts/sablier/templates/sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sablier-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/sablier/templates/service.yaml
+++ b/charts/sablier/templates/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sablier-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: sablier-{{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 10000
+      targetPort: 10000

--- a/charts/sablier/tests/deployement_test.yaml
+++ b/charts/sablier/tests/deployement_test.yaml
@@ -1,0 +1,203 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Sablier Deployement Generation manifest
+templates:
+  - "deployement.yaml"
+release:
+  name: test-sablier
+  namespace: sablier
+tests:
+  - it: should create 1 sablier deployement
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: sablier-test-sablier
+      - equal:
+          path: metadata.namespace
+          value: sablier
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: sablier-test-sablier
+  - it: should add deployementLabels
+    set:
+      deploymentLabels:
+        random: test
+        random2: test2
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: sablier-test-sablier
+            random: test
+            random2: test2
+  - it: should not add deployments labels
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app: sablier-test-sablier
+  - it: should add deployementAnnotations
+    set:
+      deploymentAnnotations:
+        random: test
+        random2: test2
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            random: test
+            random2: test2
+  - it: should not add deployment annotations
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should override replicas
+    set:
+      replicas: 10
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 10
+  - it: should add podLabels
+    set:
+      podLabels:
+        label1: hello
+        labels2: world
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app: sablier-test-sablier
+            label1: hello
+            labels2: world
+
+  - it: should not add podLabels
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app: sablier-test-sablier
+  - it: should add podAnnotations
+    set:
+      podAnnotations:
+        annotations1: hello
+        annotations2: world
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            annotations1: hello
+            annotations2: world
+  - it: should not add podAnnotations
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+  - it: shoudl set sablier loglevel
+    set:
+      logLevel: debug
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            ["start", "--provider.name=kubernetes", "--logging.level=debug"]
+  - it: should set sablier livenessProbe
+    set:
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 10001
+        initialDelaySeconds: 7
+        timeoutSeconds: 2
+        successThreshold: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /healthz
+              port: 10001
+            initialDelaySeconds: 7
+            periodSeconds: 5
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+  - it: should set sablier readinessProbe
+    set:
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 10000
+        initialDelaySeconds: 7
+        periodSeconds: 5
+        timeoutSeconds: 1
+        successThreshold: 1
+        failureThreshold: 3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /healthz
+              port: 10000
+            initialDelaySeconds: 7
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+  - it: should set sablier resource
+    set:
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+  - it: should set empty resource
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value: {}
+  - it: should set new tag and image repository
+    set:
+      image:
+        tag: 1.1.1
+        repository: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test:1.1.1
+  - it: should set new tag only
+    set:
+      image:
+        tag: 1.1.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: acouvreur/sablier:1.1.1
+  - it: should override deployment strategy
+    set:
+      deploymentStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 50%
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 50%
+              maxSurge: 25%

--- a/charts/sablier/tests/rbac_test.yaml
+++ b/charts/sablier/tests/rbac_test.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Sablier RBAC Generation manifest
+templates:
+  - "rbac.yaml"
+release:
+  name: test-sablier
+  namespace: sablier
+tests:
+  - it: should create rbac
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: should correctly set ClusterRole
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - equal:
+          path: metadata.name
+          value: sablier-test-sablier
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - apps
+                - ""
+              resources:
+                - deployments
+                - deployments/scale
+                - statefulsets
+                - statefulsets/scale
+              verbs:
+                - patch # Scale up and down
+                - get # Retrieve info about specific dep
+                - update # Scale up and down
+                - list # Events
+                - watch # Events
+  - it: should correctly set ClusterRoleBinding
+    documentSelector:
+      path: kind
+      value: ClusterRoleBinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: sablier-test-sablier
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: sablier-test-sablier
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: sablier
+              namespace: sablier

--- a/charts/sablier/tests/sa_test.yaml
+++ b/charts/sablier/tests/sa_test.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Sablier ServiceAccount Generation manifest
+templates:
+  - "sa.yaml"
+release:
+  name: test-sablier
+  namespace: sablier
+tests:
+  - it: should create sablier service
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: should correctly name sablier serviceAccount
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: sablier-test-sablier
+      - equal:
+          path: metadata.namespace
+          value: sablier

--- a/charts/sablier/tests/service_test.yaml
+++ b/charts/sablier/tests/service_test.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Sablier Service Generation manifest
+templates:
+  - "service.yaml"
+release:
+  name: test-sablier
+  namespace: sablier
+tests:
+  - it: should create sablier service
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: should correctly name sablier service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: sablier-test-sablier
+      - equal:
+          path: spec.selector
+          value:
+            app: sablier-test-sablier
+      - equal:
+          path: metadata.namespace
+          value: sablier

--- a/charts/sablier/values.yaml
+++ b/charts/sablier/values.yaml
@@ -36,7 +36,7 @@ imagePullPolicy: IfNotPresent
 # -- Sablier readinessProbe
 readinessProbe:
   httpGet:
-    path: /healthz
+    path: /health
     port: 10000
   initialDelaySeconds: 5
   periodSeconds: 5
@@ -47,7 +47,7 @@ readinessProbe:
 # -- Sablier livenessProbe
 livenessProbe:
   httpGet:
-    path: /healthz
+    path: /health
     port: 10000
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/charts/sablier/values.yaml
+++ b/charts/sablier/values.yaml
@@ -1,0 +1,65 @@
+# -- Annotations for all deployed Deployments
+deploymentAnnotations: {}
+
+# -- Labels for all deployed Deployments
+deploymentLabels: {}
+
+# -- Annotations for all deployed pods
+podAnnotations: {}
+
+# -- Labels for all deployed pods
+podLabels: {}
+
+# -- Deployment strategy for all deployed Deployments
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+# -- Sablier's replicas
+replicas: 1
+
+# -- Sablier log level
+logLevel: "trace"
+
+image:
+  # -- Sablier image repository
+  repository: "acouvreur/sablier"
+
+  # -- Sablier image tag
+  # (deafult) appVersion
+  tag: ""
+
+# -- Sablier imagePullPolicy
+imagePullPolicy: IfNotPresent
+
+# -- Sablier readinessProbe
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 10000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+# -- Sablier livenessProbe
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 10000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+# -- Resource limits and requests for sablier
+resources: {}
+# requests:
+#   memory: "64Mi"
+#   cpu: "250m"
+# limits:
+#   memory: "128Mi"
+#   cpu: "500m"


### PR DESCRIPTION
Hi , like i said i n the issue, seems to be a good idea to have a chart to easily deploy sablier

* templates
* unittest
* ci-lint test (ct lint/install  and helm unittest)
* readme generation docs with helm-docs
* ct-releaser => may not fully functionnal

NB: not very used to work with gh-actions, double check ^^

Closed: #271