### PR TITLE
fix(providers): add `docker_swarm` as a provider

### DIFF
--- a/app/providers/provider.go
+++ b/app/providers/provider.go
@@ -22,12 +22,16 @@ type Provider interface {
 }
 
 func NewProvider(config config.Provider) (Provider, error) {
-	switch {
-	case config.Name == "swarm":
+	if err := config.IsValid(); err != nil {
+		return nil, err
+	}
+
+	switch config.Name {
+	case "swarm", "docker_swarm":
 		return NewDockerSwarmProvider()
-	case config.Name == "docker":
+	case "docker":
 		return NewDockerClassicProvider()
-	case config.Name == "kubernetes":
+	case "kubernetes":
 		return NewKubernetesProvider(config.Kubernetes)
 	}
 	return nil, fmt.Errorf("unimplemented provider %s", config.Name)

--- a/config/provider.go
+++ b/config/provider.go
@@ -18,7 +18,7 @@ type Kubernetes struct {
 	Burst int `mapstructure:"BURST" yaml:"Burst" default:"10"`
 }
 
-var providers = []string{"docker", "swarm", "kubernetes"}
+var providers = []string{"docker", "docker_swarm", "swarm", "kubernetes"}
 
 func NewProviderConfig() Provider {
 	return Provider{

--- a/docs/providers/docker_swarm.md
+++ b/docs/providers/docker_swarm.md
@@ -12,19 +12,19 @@ In order to use the docker provider you can configure the [provider.name](TODO) 
 
 ```yaml
 provider:
-  name: docker_swarm
+  name: docker_swarm # or swarm
 ```
 
 #### **CLI**
 
 ```bash
-sablier start --provider.name=docker_swarm
+sablier start --provider.name=docker_swarm # or swarm
 ```
 
 #### **Environment Variable**
 
 ```bash
-PROVIDER_NAME=docker_swarm
+PROVIDER_NAME=docker_swarm # or swarm
 ```
 
 <!-- tabs:end -->
@@ -38,7 +38,7 @@ services:
     image: acouvreur/sablier:1.6.0
     command:
       - start
-      - --provider.name=docker_swarm
+      - --provider.name=docker_swarm # or swarm
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
 ```

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -12,14 +12,14 @@ A Provider typically have the following capabilities:
 
 ## Available providers
 
-| Provider                                | Name           | Details                                                     |
-| --------------------------------------- | -------------- | ----------------------------------------------------------- |
-| [Docker](/providers/docker)             | `docker`       | Stop and start **containers** on demand                         |
-| [Docker Swarm](/providers/docker_swarm) | `docker_swarm` | Scale down to zero and up **services** on demand                |
-| [Kubernetes](/providers/kubernetes)     | `kubernetes`   | Scale down and up **deployments** and **statefulsets** on demand    |
-| [Podman](/providers/podman)             | `podman`       | [See #70](https://github.com/acouvreur/sablier/issues/70)   |
-| [ECS](/providers/ec2)                   | `ecs`          | [See #116](https://github.com/acouvreur/sablier/issues/116) |
-| [Systemd](/providers/systemd)           | `systemd`      | [See #148](https://github.com/acouvreur/sablier/issues/148) |
+| Provider                                | Name                      | Details                                                          |
+| --------------------------------------- | ------------------------- | ---------------------------------------------------------------- |
+| [Docker](/providers/docker)             | `docker`                  | Stop and start **containers** on demand                          |
+| [Docker Swarm](/providers/docker_swarm) | `docker_swarm` or `swarm` | Scale down to zero and up **services** on demand                 |
+| [Kubernetes](/providers/kubernetes)     | `kubernetes`              | Scale down and up **deployments** and **statefulsets** on demand |
+| [Podman](/providers/podman)             | `podman`                  | [See #70](https://github.com/acouvreur/sablier/issues/70)        |
+| [ECS](/providers/ec2)                   | `ecs`                     | [See #116](https://github.com/acouvreur/sablier/issues/116)      |
+| [Systemd](/providers/systemd)           | `systemd`                 | [See #148](https://github.com/acouvreur/sablier/issues/148)      |
 
 *Your Provider is not on the list? [Open an issue to request the missing provider here!](https://github.com/acouvreur/sablier/issues/new?assignees=&labels=enhancement%2C+provider&projects=&template=instance-provider-request.md&title=Add+%60%5BPROVIDER%5D%60+provider)*
 


### PR DESCRIPTION
Currently the documentation states that `docker_swarm` is an acceptable value for the Docker Swarm provider. However, the code actually uses `swarm`.

This changes adds `docker_swarm` as a supported provider alias for docker swarm.

Closes #279