### PR TITLE
Update docker_classic.go with delay

### DIFF
--- a/app/providers/docker_classic.go
+++ b/app/providers/docker_classic.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
+        "time"
 	"github.com/docker/docker/api/types/container"
 
 	"github.com/acouvreur/sablier/app/instance"

--- a/app/providers/docker_classic.go
+++ b/app/providers/docker_classic.go
@@ -152,8 +152,14 @@ func (provider *DockerClassicProvider) NotifyInstanceStopped(ctx context.Context
 				log.Debug("provider event stream closed")
 				return
 			}
+            		if err != nil {
+                		log.Error("error while processing Docker events:", err)
+            		}			
 		case <-ctx.Done():
 			return
+        	default:
+            		// Add a small delay to prevent high CPU usage
+            		time.Sleep(100 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
This change addresses the issue reported in Issue #287, where the CPU load reaches 100% when the DOCKER_HOST environment variable is set to a value other than the default /var/run/docker.sock. The infinite loop in the NotifyInstanceStopped method was causing excessive CPU usage due to continuous polling without any delay. Introducing a small delay (100 milliseconds) in the loop reduces CPU load while maintaining functionality.  This modification ensures that the event loop does not consume excessive CPU resources, especially when connected to a remote Docker host.