### PR TITLE
fix(docker): move sablier binary from /etc/sablier/sablier to /bin/sablier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ FROM alpine:3.20.1
 RUN mkdir -p /etc/sablier/themes
 EXPOSE 10000
 
-COPY --from=build /src/sablier* /etc/sablier/sablier
+COPY --from=build /src/sablier* /bin/sablier
 COPY docker/sablier.yaml /etc/sablier/sablier.yaml
 
-ENTRYPOINT [ "/etc/sablier/sablier" ]
+ENTRYPOINT [ "sablier" ]
 CMD [ "--configFile=/etc/sablier/sablier.yaml", "start" ]


### PR DESCRIPTION
As the Dockerfile is using an Alpine image for the final layer, it should try to respect Alpine and Linux FHS as much as possible.

Note that the config file will remain in /etc/sablier/ folder

Fixes #348